### PR TITLE
User can configure fields and childrelationships from getting serialized

### DIFF
--- a/apex-sobjectdataloader/src/classes/SObjectDataLoader.cls
+++ b/apex-sobjectdataloader/src/classes/SObjectDataLoader.cls
@@ -40,8 +40,8 @@ public with sharing class SObjectDataLoader
 		protected Set<Schema.SObjectField> followRelationships;
 		protected Set<Schema.SObjectField> followChildRelationships;
 		protected Set<Schema.SObjectField> omitFields;
-		protected Map<String,List<String>> userFieldBlackListMap;
-		protected Map<String,List<String>> userChildRelationshipBlackListMap;
+		protected Map<String,List<String>> userFieldWhiteListMap;
+		protected Map<String,List<String>> userChildRelationshipWhiteListMap;
 		protected Set<String> blacklistedNamespacePrefix;
 		protected Boolean omitCurrencyField;
 		protected Map<Schema.SObjectType, Map<String, Schema.SObjectField>> objectFieldDescribeMap;
@@ -52,8 +52,8 @@ public with sharing class SObjectDataLoader
 			followRelationships = new Set<Schema.SObjectField>();
 			followChildRelationships = new Set<Schema.SObjectField>();
 			omitFields = new Set<Schema.SObjectField>(); 	
-			userFieldBlackListMap = new Map<String,List<String>>();	
-			userChildRelationshipBlackListMap = new Map<String,List<String>>();		
+			userFieldWhiteListMap = new Map<String,List<String>>();	
+			userChildRelationshipWhiteListMap = new Map<String,List<String>>();		
 			blacklistedNamespacePrefix = new Set<String>();
 			omitCurrencyField =false;
 			objectFieldDescribeMap = new Map<Schema.SObjectType, Map<String, Schema.SObjectField>>();
@@ -109,18 +109,18 @@ public with sharing class SObjectDataLoader
 		/**
 		 * Provide a map that represents the object field relationship the serializer should whitelist
 		 **/
-		public SerializeConfig addToUserChildRelationShipBlackList(Map<String,List<String>> childRelationShipBlackListMap)
+		public SerializeConfig addToUserChildRelationShipWhiteList(Map<String,List<String>> childRelationShipWhiteListMap)
 		{
-			userChildRelationshipBlackListMap.putAll(childRelationShipBlackListMap);
+			UserChildRelationshipWhiteListMap.putAll(childRelationShipWhiteListMap);
 			return this;
 		}
 		
 		/**
 		 * Provide a map that represents the object child relationship the serializer should whitelist
 		 **/
-		public SerializeConfig addToUserFieldBlackList(Map<String,List<String>> fieldBlackListMap)
+		public SerializeConfig addToUserFieldWhiteList(Map<String,List<String>> FieldWhiteListMap)
 		{
-			userFieldBlackListMap.putAll(fieldBlackListMap);
+			userFieldWhiteListMap.putAll(FieldWhiteListMap);
 			return this;
 		}
 		
@@ -165,17 +165,17 @@ public with sharing class SObjectDataLoader
 			if(searchChildren)
 			{
 				List<Schema.ChildRelationship> childRelationships = sObjectDescribe.getChildRelationships();
-				Set<String> userChildRelationshipBlackListSet = new Set<String>();		
-				if(userChildRelationshipBlackListMap.get(sObjectName)!= null && userChildRelationshipBlackListMap.get(sObjectName).size()>0)
+				Set<String> userChildRelationshipWhiteListSet = new Set<String>();		
+				if(userChildRelationshipWhiteListMap.get(sObjectName)!= null && userChildRelationshipWhiteListMap.get(sObjectName).size()>0)
 				{
-					userChildRelationshipBlackListSet.addAll(userChildRelationshipBlackListMap.get(sObjectName));
+					userChildRelationshipWhiteListSet.addAll(userChildRelationshipWhiteListMap.get(sObjectName));
 				}
 				for(Schema.ChildRelationship childRelationship : childRelationships)
 				{
 					// Determine which child relationships to automatically follow
 					String childRelationshipName = childRelationship.getRelationshipName();
 					if(childRelationshipName==null || 
-					   childRelationshipWhitelist.contains(childRelationshipName) || userChildRelationshipBlackListSet.contains(childRelationshipName) || matchNameSpaceForObject(childRelationshipName)) // Skip relationships without names and those whitelisted
+					   childRelationshipWhitelist.contains(childRelationshipName) || userChildRelationshipWhiteListSet.contains(childRelationshipName) || matchNameSpaceForObject(childRelationshipName)) // Skip relationships without names and those whitelisted
 						continue;
 					if(childRelationshipName.endsWith('Histories')) // Skip relationships ending in Histories (TODO: consider a RegEx approach?)
 						continue;
@@ -192,10 +192,10 @@ public with sharing class SObjectDataLoader
 				objectFieldDescribeMap.put(sObjectType, sObjectFields);
 			}
 			
-			Set<String> userBlackListSet = new Set<String>();
-			if(userFieldBlackListMap.get(sObjectName)!= null && userFieldBlackListMap.get(sObjectName).size()>0)
+			Set<String> userWhiteListSet = new Set<String>();
+			if(userFieldWhiteListMap.get(sObjectName)!= null && userFieldWhiteListMap.get(sObjectName).size()>0)
 			{
-				userBlackListSet.addAll(userFieldBlackListMap.get(sObjectName));
+				userWhiteListSet.addAll(userFieldWhiteListMap.get(sObjectName));
 			}			
 			// Follow lookup relationships to long as they have not previously been added as child references and are not whitelisted
 			//If the Sobject Field is referenceTo as 'User' and 'Organization' then restrict it to search its Relationships 
@@ -208,14 +208,14 @@ public with sharing class SObjectDataLoader
 						if(referenceToWhitelist.contains(refernceToType.getDescribe().getName()))
 							omitRefernceToFields = true;
 					}
-					if(!followChildRelationships.contains(sObjectField) && !relationshipWhitelist.contains(sObjectField.getDescribe().getName()) && !omitRefernceToFields && !userBlackListSet.contains(sObjectField.getDescribe().getName()) && !matchNameSpaceForObject(sObjectField.getDescribe().getName()))
+					if(!followChildRelationships.contains(sObjectField) && !relationshipWhitelist.contains(sObjectField.getDescribe().getName()) && !omitRefernceToFields && !userWhiteListSet.contains(sObjectField.getDescribe().getName()) && !matchNameSpaceForObject(sObjectField.getDescribe().getName()))
 					{
 						if(sObjectField.getDescribe().getReferenceTo()!=null && sObjectField.getDescribe().getReferenceTo().size()>0)
 							follow(sObjectField).
 								searchRelationships(sObjectField.getDescribe().getReferenceTo()[0], lookupDepth+1, childDepth, false, searched, searchedParentOnly);
 					}
 				}
-				else if(userBlackListSet.contains(sObjectField.getDescribe().getName()) || matchNameSpaceForObject(sObjectField.getDescribe().getName()))
+				else if(userWhiteListSet.contains(sObjectField.getDescribe().getName()) || matchNameSpaceForObject(sObjectField.getDescribe().getName()))
 				{
                 	omit(sObjectField);
 				}

--- a/apex-sobjectdataloader/src/classes/SObjectDataLoader.cls
+++ b/apex-sobjectdataloader/src/classes/SObjectDataLoader.cls
@@ -40,13 +40,22 @@ public with sharing class SObjectDataLoader
 		protected Set<Schema.SObjectField> followRelationships;
 		protected Set<Schema.SObjectField> followChildRelationships;
 		protected Set<Schema.SObjectField> omitFields;
-        protected Map<Schema.SObjectType, Map<String, Schema.SObjectField>> objectFieldDescribeMap;
+		protected Map<String,List<String>> userFieldBlackListMap;
+		protected Map<String,List<String>> userChildRelationshipBlackListMap;
+		protected Set<String> blacklistedNamespacePrefix;
+		protected Boolean omitCurrencyField;
+		protected Map<Schema.SObjectType, Map<String, Schema.SObjectField>> objectFieldDescribeMap;
+		
 		
 		public SerializeConfig()
 		{	
 			followRelationships = new Set<Schema.SObjectField>();
 			followChildRelationships = new Set<Schema.SObjectField>();
-			omitFields = new Set<Schema.SObjectField>(); 			
+			omitFields = new Set<Schema.SObjectField>(); 	
+			userFieldBlackListMap = new Map<String,List<String>>();	
+			userChildRelationshipBlackListMap = new Map<String,List<String>>();		
+			blacklistedNamespacePrefix = new Set<String>();
+			omitCurrencyField =false;
 			objectFieldDescribeMap = new Map<Schema.SObjectType, Map<String, Schema.SObjectField>>();
 		}
 		
@@ -97,6 +106,44 @@ public with sharing class SObjectDataLoader
 		}
 		
 		/**
+		 * Provide a map that represents the object field relationship the serializer should whitelist
+		 **/
+		public SerializeConfig addToUserChildRelationShipBlackList(Map<String,List<String>> childRelationShipBlackListMap)
+		{
+			userChildRelationshipBlackListMap.putAll(childRelationShipBlackListMap);
+			return this;
+		}
+		
+		/**
+		 * Provide a map that represents the object child relationship the serializer should whitelist
+		 **/
+		public SerializeConfig addToUserFieldBlackList(Map<String,List<String>> fieldBlackListMap)
+		{
+			userFieldBlackListMap.putAll(fieldBlackListMap);
+			return this;
+		}
+		
+		public SerializeConfig addToBlacklistedNamespace(Set<String> NamespaceList)
+		{
+			blacklistedNamespacePrefix.addAll(NamespaceList);
+			return this;
+		}
+		
+		/**
+		 * Method adds blacklist Fields common for all Objects to fieldWhitelist 
+		**/
+		public SerializeConfig omitCommonFields(Set<String> fieldnames)
+		{
+			if(fieldnames!=null && fieldnames.size()>0)
+			{
+				fieldWhitelist.addAll(fieldnames);
+				if(fieldnames.contains('CurrencyIsoCode'))
+					omitCurrencyField = true;
+			}
+			return this;
+		}
+		
+		/**
 		 * Seek out recursively relationships
 		 **/
 		private void searchRelationships(Schema.SObjectType sObjectType, Integer lookupDepth, Integer childDepth, Boolean searchChildren, Set<Schema.SObjectType> searched)
@@ -106,18 +153,22 @@ public with sharing class SObjectDataLoader
 				return;
 			searched.add(sObjectType);
 			Schema.DescribeSObjectResult sObjectDescribe = sObjectType.getDescribe();
-						
+			String sObjectName = sObjectType.getDescribe().getName();
 			// Following children? (only set for descendents of the top level object)
 			if(searchChildren)
 			{
-				List<Schema.ChildRelationship> childRelationships;
-					childRelationships = sObjectDescribe.getChildRelationships();
+				List<Schema.ChildRelationship> childRelationships = sObjectDescribe.getChildRelationships();
+				Set<String> userChildRelationshipBlackListSet = new Set<String>();		
+				if(userChildRelationshipBlackListMap.get(sObjectName)!= null && userChildRelationshipBlackListMap.get(sObjectName).size()>0)
+				{
+					userChildRelationshipBlackListSet.addAll(userChildRelationshipBlackListMap.get(sObjectName));
+				}
 				for(Schema.ChildRelationship childRelationship : childRelationships)
 				{
 					// Determine which child relationships to automatically follow
 					String childRelationshipName = childRelationship.getRelationshipName();
 					if(childRelationshipName==null || 
-					   childRelationshipWhitelist.contains(childRelationshipName)) // Skip relationships without names and those whitelisted
+					   childRelationshipWhitelist.contains(childRelationshipName) || userChildRelationshipBlackListSet.contains(childRelationshipName) || matchNameSpaceForObject(childRelationshipName)) // Skip relationships without names and those whitelisted
 						continue;
 					if(childRelationshipName.endsWith('Histories')) // Skip relationships ending in Histories (TODO: consider a RegEx approach?)
 						continue;
@@ -127,9 +178,6 @@ public with sharing class SObjectDataLoader
 						searchRelationships(childRelationship.getChildSObject(), lookupDepth, childDepth+1, true, searched);
 				}
 			}
-							
-			// Follow lookup relationships to long as they have not previously been added as child references and are not whitelisted
-			//throw new ConsultingToolException('Error in SobjectDataLoader');
 			Map<String, Schema.SObjectField> sObjectFields = objectFieldDescribeMap.get(sObjectType);
 			if (sObjectFields == null)
 			{
@@ -137,7 +185,14 @@ public with sharing class SObjectDataLoader
 				objectFieldDescribeMap.put(sObjectType, sObjectFields);
 			}
 			
+			Set<String> userBlackListSet = new Set<String>();
+			if(userFieldBlackListMap.get(sObjectName)!= null && userFieldBlackListMap.get(sObjectName).size()>0)
+			{
+				userBlackListSet.addAll(userFieldBlackListMap.get(sObjectName));
+			}			
+			// Follow lookup relationships to long as they have not previously been added as child references and are not whitelisted
 			//If the Sobject Field is referenceTo as 'User' and 'Organization' then restrict it to search its Relationships 
+
 			for(Schema.SObjectField sObjectField : sObjectFields.values())
 				if(sObjectField.getDescribe().getType() == Schema.DisplayType.Reference)
 				{
@@ -146,17 +201,31 @@ public with sharing class SObjectDataLoader
 						if(referenceToWhitelist.contains(refernceToType.getDescribe().getName()))
 							omitRefernceToFields = true;
 					}
-					if(!followChildRelationships.contains(sObjectField) && !relationshipWhitelist.contains(sObjectField.getDescribe().getName()) && !omitRefernceToFields)
-					{
-						if(sObjectField.getDescribe().getReferenceTo()!=null && sObjectField.getDescribe().getReferenceTo().size()>0)
-							follow(sObjectField).
-								searchRelationships(sObjectField.getDescribe().getReferenceTo()[0], lookupDepth+1, childDepth, false, searched);
-					}
+					if(!followChildRelationships.contains(sObjectField) && !relationshipWhitelist.contains(sObjectField.getDescribe().getName()) && !omitRefernceToFields && !userBlackListSet.contains(sObjectField.getDescribe().getName()) && !matchNameSpaceForObject(sObjectField.getDescribe().getName()))
+						follow(sObjectField).
+							searchRelationships(sObjectField.getDescribe().getReferenceTo()[0], lookupDepth+1, childDepth, false, searched);
 				}
-                else if (fieldWhitelist.contains(sObjectField.getDescribe().getName()))
+				else if(userBlackListSet.contains(sObjectField.getDescribe().getName()) || matchNameSpaceForObject(sObjectField.getDescribe().getName()))
+				{
+                	omit(sObjectField);
+				}
+                else if(fieldWhitelist.contains(sObjectField.getDescribe().getName()))
+                {
                     omit(sObjectField);
+                } 
 		}
 
+		private Boolean matchNameSpaceForObject(String ObjectName)
+		{
+			Boolean namespaceMatched = false;
+			for(String namespaceExcluded : blacklistedNamespacePrefix)
+			{
+				namespaceExcluded = namespaceExcluded.trim()+'__';
+				if(ObjectName.startsWith(namespaceExcluded))
+					namespaceMatched = true;
+			}
+			return namespaceMatched;
+		} 
 		// Standard fields that are not included when using the auto config
 		private Set<String> relationshipWhitelist = 
 			new Set<String>
@@ -182,7 +251,13 @@ public with sharing class SObjectDataLoader
 				  'NotesAndAttachments', 
 				  'OpenActivities', 
 				  'Histories', 
-				  'Feeds'};		
+				  'Feeds',
+				  'CombinedAttachments',
+                  'ContentDocuments',
+                  'ContentVersions',
+                  'AttachedContentDocuments',
+                  'RecordAssociatedGroups'
+				  };		
 	
 		// Standard RefernceTo that are not included when using the auto config	
 		private Set<String> referenceToWhitelist = 
@@ -197,7 +272,7 @@ public with sharing class SObjectDataLoader
                 {
                 	'LastViewedDate',
                 	'LastReferencedDate',
-			//below fields are compound fields
+                	//below fields are compound fields
                 	'MailingAddress',
                 	'OtherAddress',
                 	'BillingAddress',
@@ -272,11 +347,12 @@ public with sharing class SObjectDataLoader
 				recordMapToSerialize.put(sObjectType,idSet);
 			}
 		}
-		
+		Map<String,Set<Id>> processedIds = new Map<String,Set<Id>>();
+		Map<Id, SObject> recordsSerialized = new Map<Id, Sobject>();
 		Set<Schema.SObjectType> sObjectTypeSet = recordMapToSerialize.keySet();
 		for(Schema.SObjectType sobjectTypes : sObjectTypeSet)
 		{
-			serialize(recordMapToSerialize.get(sobjectTypes), sobjectTypes, null, strategyBySObjectType.get(sobjectTypes), 0, 0, recordsToBundle);
+			serialize(recordMapToSerialize.get(sobjectTypes), sobjectTypes, null, strategyBySObjectType.get(sobjectTypes), 0, 0, recordsToBundle, processedIds, recordsSerialized);
 		}		
 		// Serialise the records bundle container		
 		return JSON.serialize(recordsToBundle);		 		
@@ -474,7 +550,7 @@ public with sharing class SObjectDataLoader
         }
     }
 
-	private static void serialize(Set<ID> ids, Schema.SObjectType sObjectType, Schema.SObjectField queryByIdField, SerializeConfig config, Integer lookupDepth, Integer childDepth, RecordsBundle recordsToBundle)
+	private static void serialize(Set<ID> ids, Schema.SObjectType sObjectType, Schema.SObjectField queryByIdField, SerializeConfig config, Integer lookupDepth, Integer childDepth, RecordsBundle recordsToBundle, Map<String,Set<ID>> processedIds, Map<Id,SObject> recordsSerialized)
 	{		
 		// Config?
 		if(config==null)
@@ -485,10 +561,9 @@ public with sharing class SObjectDataLoader
 			
 		// Describe object and determine fields to serialize
 		Schema.DescribeSObjectResult sObjectDesc = sObjectType.getDescribe();
-		
+
 		//updating so that the we dont query for objects that cannot be queried:-
 		if(!sObjectDesc.queryable || !sObjectDesc.isCreateable()) return;
-		
 		Map<String, Schema.SObjectField> sObjectFields = config.objectFieldDescribeMap.get(sObjectType);
 		if (sObjectFields == null)
 		{
@@ -499,11 +574,51 @@ public with sharing class SObjectDataLoader
 						
 		// Query records to serialize
 		String fieldList = null;
-		for(Schema.SObjectField sObjectField : sObjectFieldsToSerialize)
-			fieldList = fieldList == null ? sObjectField.getDescribe().getName() : fieldList + ',' + sObjectField.getDescribe().getName();
-		String query = String.format('select {0} from {1} where {2} in :ids order by {2}', 
-			new List<String> { fieldList, sObjectDesc.getName(), queryByIdField == null ? 'id' : queryByIdField.getDescribe().getName(), 'Name' });
-		Map<Id, SObject> recordsToSerializeById = new Map<Id, SObject>(Database.query(query));
+		Map<Id, SObject> recordsToSerializeById;
+		Boolean queryRecord = true;
+		Set <Id> processedIdSet;
+		if(queryByIdField == null)
+		{
+			if(processedIds.get(sObjectDesc.getName())==null)
+			{
+				processedIds.put(sObjectDesc.getName(),ids);
+			}
+			else
+			{
+				processedIdSet = processedIds.get(sObjectDesc.getName());
+				if(processedIdSet.containsAll(ids))
+				{
+					queryRecord = false;
+				}
+				else
+				{
+					processedIdSet.addAll(ids);
+					processedIds.put(sObjectDesc.getName(),processedIdSet);
+				}
+			}
+		}
+		if(queryRecord)
+		{
+			List<String> updatableObjectfields = new List<String>();
+			for(Schema.SObjectField sObjectField : sObjectFieldsToSerialize)
+			{
+				if(sObjectField.getDescribe().isUpdateable())
+				{
+					updatableObjectfields.add(sObjectField.getDescribe().getName());
+				}
+				fieldList = fieldList == null ? sObjectField.getDescribe().getName() : fieldList + ',' + sObjectField.getDescribe().getName();
+			}
+			String query = String.format('select {0} from {1} where {2} in :ids order by {2}', 
+				new List<String> { fieldList, sObjectDesc.getName(), queryByIdField == null ? 'id' : queryByIdField.getDescribe().getName(), 'Name' });
+			recordsToSerializeById = new Map<Id, SObject>(Database.query(query));
+			recordsSerialized.putAll(recordsToSerializeById);
+		}
+		else
+		{
+			recordsToSerializeById = new Map<Id, SObject>();
+			for(Id idToProcess : ids)
+				recordsToSerializeById.put(idToProcess,recordsSerialized.get(idToProcess));
+		}
 		if(recordsToSerializeById.size()==0)
 			return;
 		
@@ -530,7 +645,7 @@ public with sharing class SObjectDataLoader
 			{
 				Set<Id> relatedRecordIds = relationshipsByField.get(relationshipField);
 				if(relatedRecordIds.size()>0)
-					serialize(relatedRecordIds, relationshipField.getReferenceTo()[0], null, config, lookupDepth+1, childDepth, recordsToBundle);					
+					serialize(relatedRecordIds, relationshipField.getReferenceTo()[0], null, config, lookupDepth+1, childDepth, recordsToBundle, processedIds, recordsSerialized);					
 			}
 		}
 					
@@ -550,14 +665,13 @@ public with sharing class SObjectDataLoader
 		}
 				
 		// Any child relationships to follow?
-		List<Schema.ChildRelationship> childRelationships;
-		childRelationships = sObjectDesc.getChildRelationships();
+		List<Schema.ChildRelationship> childRelationships = sObjectDesc.getChildRelationships();
 		for(Schema.ChildRelationship childRelationship : childRelationships)
 		{ 
 			// Is this a child relationship we have been asked to follow?
 			Schema.SObjectType childSObjectType = childRelationship.getChildSObject();
 			if(config.followChildRelationships.contains(childRelationship.getField()))
-				serialize(recordsToSerializeById.keySet(), childSObjectType, childRelationship.getField(), config, lookupDepth, childDepth+1, recordsToBundle);
+				serialize(recordsToSerializeById.keySet(), childSObjectType, childRelationship.getField(), config, lookupDepth, childDepth+1, recordsToBundle,  processedIds, recordsSerialized);
 		}
 	}
 	
@@ -587,6 +701,26 @@ public with sharing class SObjectDataLoader
 			serializeFields.add(sObjectField);
 		}			
 		return serializeFields;	
+	}
+	
+	/*
+	* Method to create a Map from json file
+	*/
+	public static Map<String,List<Sobject>> deserializedRecords(String recordsBundleAsJSON)
+	{
+		Map<String,List<Sobject>> recordBundleMap = new Map<String,List<Sobject>>();
+		RecordsBundle recordsBundle = (RecordsBundle) 
+			JSON.deserialize(recordsBundleAsJSON, SObjectDataLoader.RecordsBundle.class);
+		for(RecordSetBundle recordSetBundle : recordsBundle.recordSetBundles)
+		{
+			List<Sobject> recordList = new List<Sobject>();
+			if(recordBundleMap.get(recordSetBundle.ObjectType)!= null)
+				recordList.addAll(recordBundleMap.get(recordSetBundle.ObjectType));
+			else
+				recordList.addAll(recordSetBundle.Records);
+			recordBundleMap.put(recordSetBundle.ObjectType, recordList);
+		}
+		return recordBundleMap;	
 	}
 	
 	/** 
@@ -637,5 +771,4 @@ public with sharing class SObjectDataLoader
 		public String ObjectType;
 		public List<SObject> Records;	
 	}
-	
 }

--- a/apex-sobjectdataloader/src/classes/SObjectDataLoaderTest.cls
+++ b/apex-sobjectdataloader/src/classes/SObjectDataLoaderTest.cls
@@ -468,7 +468,7 @@ private class SObjectDataLoaderTest {
     }
     
     @isTest(seeAllData=False)
-     private static void reportLimitExceptions()
+    private static void reportLimitExceptions()
     {
     	Map<String, Schema.SObjectType> globalDescribeMap = Schema.getGlobalDescribe();
     	Account accountObj = new Account(Name ='Account1');
@@ -491,6 +491,273 @@ private class SObjectDataLoaderTest {
     		error = e.getMessage();
     	}
     	system.assert(String.isBlank(error));
+	}
+    
+    @isTest(seeAllData=False)
+    private static void userFieldWhiteListTest()
+    {
+		Id idToSerialize;
+    	Map <Schema.SObjectType,SObjectDataLoader.SerializeConfig> strategyBySObjectType = new Map <Schema.SObjectType,SObjectDataLoader.SerializeConfig>();
+	 	Map<String,List<String>> fieldWhiteListMap = new Map<String,List<String>>();
+	 	fieldWhiteListMap.put('Account',new List<String>{'Site'});
+	 	Map<String, Schema.SObjectType> globalDescribeMap = Schema.getGlobalDescribe();
+    	Schema.SObjectType accSObjectType = globalDescribeMap.get('Account');
+		SObject acc = accSObjectType.newSObject();
+		acc.put('Name', 'testAccount');
+		acc.put('Site', 'testSite');
+        insert acc;
+    	
+    	idToSerialize = acc.Id;
+    	Schema.SObjectType conSObjectType = globalDescribeMap.get('Contact');
+		SObject con = conSObjectType.newSObject();
+		con.put('LastName','testContact');
+		con.put('CurrencyIsoCode','USD');
+		con.put('AccountId',acc.Id);
+		insert con;
+		
+		Schema.SObjectType sObjectType = acc.Id.getSObjectType();
+		if(strategyBySObjectType.get(sObjectType)==null)
+		{
+			SObjectDataLoader.SerializeConfig config = new SObjectDataLoader.SerializeConfig().addToUserFieldBlackList(fieldWhiteListMap);
+			strategyBySObjectType.put(sObjectType,config.auto(idToSerialize.getSObjectType()));
+		}
+		String jsonString = SObjectDataLoader.serialize(new Set<Id>{idToSerialize}, strategyBySObjectType);
+		system.assert(!jsonString.contains('testSite'),jsonString);
+		system.assert(jsonString.contains('Contact'),jsonString);
+	}
+    
+    @isTest(seeAllData=False)
+	private static void userChildWhiteListTest()
+    {
+		Id idToSerialize;
+    	Map <Schema.SObjectType,SObjectDataLoader.SerializeConfig> strategyBySObjectType = new Map <Schema.SObjectType,SObjectDataLoader.SerializeConfig>();
+	 	Map<String,List<String>> childRelationshipWhiteListMap = new Map<String,List<String>>();
+	 	childRelationshipWhiteListMap.put('Account',new List<String>{'Contacts'});
+	 	Map<String, Schema.SObjectType> globalDescribeMap = Schema.getGlobalDescribe();
+    	Schema.SObjectType accSObjectType = globalDescribeMap.get('Account');
+		SObject acc = accSObjectType.newSObject();
+		acc.put('Name', 'testAccount');
+		acc.put('Site', 'testSite');
+        insert acc;
+    	
+    	idToSerialize = acc.Id;
+    	Schema.SObjectType conSObjectType = globalDescribeMap.get('Contact');
+		SObject con = conSObjectType.newSObject();
+		con.put('LastName','testContact');
+		con.put('CurrencyIsoCode','USD');
+		con.put('AccountId',acc.Id);
+		insert con;
+		
+		Schema.SObjectType sObjectType = acc.Id.getSObjectType();
+		if(strategyBySObjectType.get(sObjectType)==null)
+		{
+			SObjectDataLoader.SerializeConfig config = new SObjectDataLoader.SerializeConfig().addToUserChildRelationShipBlackList(childRelationshipWhiteListMap);
+			strategyBySObjectType.put(sObjectType,config.auto(idToSerialize.getSObjectType()));
+		}
+		String jsonString = SObjectDataLoader.serialize(new Set<Id>{idToSerialize}, strategyBySObjectType);
+		system.assert(jsonString.contains('testSite'),jsonString);
+		system.assert(!jsonString.contains('Contact'),jsonString);
     }
     
+    @isTest(seeAllData=False)
+	private static void userFieldWhiteListTestWithPackageBlaclist()
+    {
+		Id idToSerialize;
+    	Map <Schema.SObjectType,SObjectDataLoader.SerializeConfig> strategyBySObjectType = new Map <Schema.SObjectType,SObjectDataLoader.SerializeConfig>();
+	 	Map<String,List<String>> fieldWhiteListMap = new Map<String,List<String>>();
+	 	fieldWhiteListMap.put('Account',new List<String>{'Site'});
+	 	Map<String, Schema.SObjectType> globalDescribeMap = Schema.getGlobalDescribe();
+    	Schema.SObjectType accSObjectType = globalDescribeMap.get('Account');
+		SObject acc = accSObjectType.newSObject();
+		acc.put('Name', 'testAccount');
+		acc.put('Site', 'testSite');
+        insert acc;
+    	
+    	idToSerialize = acc.Id;
+    	Schema.SObjectType conSObjectType = globalDescribeMap.get('Contact');
+		SObject con = conSObjectType.newSObject();
+		con.put('LastName','testContact');
+		con.put('CurrencyIsoCode','USD');
+		con.put('AccountId',acc.Id);
+		insert con;
+		
+		Set<String> packageNamespaceSet = new Set<String>{'abcd','pqrs'};
+		Schema.SObjectType sObjectType = acc.Id.getSObjectType();
+		if(strategyBySObjectType.get(sObjectType)==null)
+		{
+			SObjectDataLoader.SerializeConfig config = new SObjectDataLoader.SerializeConfig().addToBlacklistedNamespace(packageNamespaceSet).addToUserFieldBlackList(fieldWhiteListMap);
+			strategyBySObjectType.put(sObjectType,config.auto(idToSerialize.getSObjectType()));
+		}
+		String jsonString = SObjectDataLoader.serialize(new Set<Id>{idToSerialize}, strategyBySObjectType);
+		system.assert(!jsonString.contains('testSite'),jsonString);
+		system.assert(jsonString.contains('Contact'),jsonString);
+	}
+	
+	@isTest(seeAllData=False)
+    private static void userChildWhiteListTestWithPackageBlaclist()
+    {
+		Id idToSerialize;
+    	Map <Schema.SObjectType,SObjectDataLoader.SerializeConfig> strategyBySObjectType = new Map <Schema.SObjectType,SObjectDataLoader.SerializeConfig>();
+	 	Map<String,List<String>> childRelationshipWhiteListMap = new Map<String,List<String>>();
+	 	childRelationshipWhiteListMap.put('Account',new List<String>{'Contacts'});
+	 	Map<String, Schema.SObjectType> globalDescribeMap = Schema.getGlobalDescribe();
+    	Schema.SObjectType accSObjectType = globalDescribeMap.get('Account');
+		SObject acc = accSObjectType.newSObject();
+		acc.put('Name', 'testAccount');
+		acc.put('Site', 'testSite');
+        insert acc;
+    	
+    	idToSerialize = acc.Id;
+    	Schema.SObjectType conSObjectType = globalDescribeMap.get('Contact');
+		SObject con = conSObjectType.newSObject();
+		con.put('LastName','testContact');
+		con.put('CurrencyIsoCode','USD');
+		con.put('AccountId',acc.Id);
+		insert con;
+		
+		Set<String> packageNamespaceSet = new Set<String>{'abcd','pqrs'};
+		Schema.SObjectType sObjectType = acc.Id.getSObjectType();
+		if(strategyBySObjectType.get(sObjectType)==null)
+		{
+			SObjectDataLoader.SerializeConfig config = new SObjectDataLoader.SerializeConfig().addToBlacklistedNamespace(packageNamespaceSet).addToUserChildRelationShipBlackList(childRelationshipWhiteListMap);
+			strategyBySObjectType.put(sObjectType,config.auto(idToSerialize.getSObjectType()));
+		}
+		String jsonString = SObjectDataLoader.serialize(new Set<Id>{idToSerialize}, strategyBySObjectType);
+		system.assert(jsonString.contains('testSite'),jsonString);
+		system.assert(!jsonString.contains('Contact'),jsonString);
+	}
+
+	/*
+	* Test  omitting  fields common to all objects
+	*/
+    
+	@isTest(seeAllData=False)
+    private static void testOmitCommonFields()
+    {
+		Id idToSerialize;
+    	Map <Schema.SObjectType,SObjectDataLoader.SerializeConfig> strategyBySObjectType = new Map <Schema.SObjectType,SObjectDataLoader.SerializeConfig>();
+	 	Map<String,List<String>> childRelationshipWhiteListMap = new Map<String,List<String>>();
+	 	Map<String, Schema.SObjectType> globalDescribeMap = Schema.getGlobalDescribe();
+    	Schema.SObjectType accSObjectType = globalDescribeMap.get('Account');
+		SObject acc = accSObjectType.newSObject();
+		acc.put('Name', 'testAccount');
+		acc.put('Site', 'testSite');
+        insert acc;
+		if(UserInfo.IsMultiCurrencyOrganization())
+		{
+			String serializedRecord = SObjectDataLoader.serialize(new Set<Id>{acc.Id}, new SObjectDataLoader.SerializeConfig().omitCommonFields(new Set<String>{'CurrencyIsoCode'}).auto(acc.Id.getSObjectType()));
+			System.assert(!serializedRecord.contains('CurrencyIsoCode'));
+		}
+		else
+		{
+			String serializedRecord = SObjectDataLoader.serialize(new Set<Id>{acc.Id}, new SObjectDataLoader.SerializeConfig().auto(acc.Id.getSObjectType()));
+			System.assert(!serializedRecord.contains('CurrencyIsoCode'));
+		}
+    }
+    
+    /*
+	* Test  omitting  fields compound for Account Object
+	*/
+	@isTest(seeAllData=False)
+	private static void testOmitCompoundFieldsForAccount()
+    {
+		Id idToSerialize;
+    	Map <Schema.SObjectType,SObjectDataLoader.SerializeConfig> strategyBySObjectType = new Map <Schema.SObjectType,SObjectDataLoader.SerializeConfig>();
+	 	Map<String,List<String>> childRelationshipWhiteListMap = new Map<String,List<String>>();
+	 	Map<String, Schema.SObjectType> globalDescribeMap = Schema.getGlobalDescribe();
+    	Schema.SObjectType accSObjectType = globalDescribeMap.get('Account');
+		SObject acc = accSObjectType.newSObject();
+		acc.put('Name', 'testAccount');
+		acc.put('Site', 'testSite');
+		acc.put('BillingCity', 'abcCity');
+		acc.put('BillingCountry', 'abcCountry');
+		acc.put('BillingState', 'abcState');
+		acc.put('ShippingCity', 'defCity');
+		acc.put('ShippingCountry', 'defCountry');
+        insert acc;
+		String serializedRecord = SObjectDataLoader.serialize(new Set<Id>{acc.Id}, new SObjectDataLoader.SerializeConfig().auto(acc.Id.getSObjectType()));
+		Set<Id> accIdSet = SObjectDataLoader.deserialize(serializedRecord);
+		System.assertEquals(1, accIdSet.size());
+		List<Account> accList = [select Name, BillingCity, BillingCountry, BillingState, BillingStreet, ShippingCity, ShippingCountry from Account where Id in :accIdSet];
+		System.assertEquals(1,accList.size());
+		System.assertEquals('abcCity',accList[0].BillingCity);
+		System.assertEquals('defCountry',accList[0].ShippingCountry);
+    }
+    
+    /*
+	* Test  omitting  fields compound for Contact Object
+	*/
+	@isTest(seeAllData=False)
+	private static void testOmitCompoundFieldsForContact()
+    {
+		Id idToSerialize;
+    	Map <Schema.SObjectType,SObjectDataLoader.SerializeConfig> strategyBySObjectType = new Map <Schema.SObjectType,SObjectDataLoader.SerializeConfig>();
+	 	Map<String,List<String>> childRelationshipWhiteListMap = new Map<String,List<String>>();
+	 	Map<String, Schema.SObjectType> globalDescribeMap = Schema.getGlobalDescribe();
+    	Schema.SObjectType conSObjectType = globalDescribeMap.get('Contact');
+		SObject con = conSObjectType.newSObject();
+		con.put('LastName','testContact');
+		con.put('MailingState', 'abcState');
+		con.put('MailingCountry', 'abcCountry');
+		con.put('MailingPostalCode', '123456');
+		con.put('MailingStreet', 'abcStreet');
+		con.put('MailingCity', 'abcCity');
+		con.put('OtherCity', 'defCity');
+		con.put('OtherCountry', 'defCountry');
+		con.put('OtherPostalCode', '234561');
+		con.put('OtherState', 'defState');
+        insert con;
+		String serializedRecord = SObjectDataLoader.serialize(new Set<Id>{con.Id}, new SObjectDataLoader.SerializeConfig().auto(con.Id.getSObjectType()));
+		Set<Id> conIdSet = SObjectDataLoader.deserialize(serializedRecord);
+		System.assertEquals(1, conIdSet.size());
+		List<Contact> conList = [select LastName, MailingState, MailingCountry, MailingPostalCode, MailingStreet, MailingCity, OtherCity, OtherCountry, OtherPostalCode, OtherState from Contact where Id in :conIdSet];
+		System.assertEquals(1,conList.size());
+		System.assertEquals('abcState',conList[0].MailingState);
+		System.assertEquals('defCountry',conList[0].OtherCountry);
+    }
+    
+     /*
+	* Test  omitting  fields compound for Lead Object
+	*/
+	@isTest(seeAllData=False)
+	private static void testOmitCompoundFieldsForLead()
+    {
+		Id idToSerialize;
+    	Map <Schema.SObjectType,SObjectDataLoader.SerializeConfig> strategyBySObjectType = new Map <Schema.SObjectType,SObjectDataLoader.SerializeConfig>();
+	 	Map<String,List<String>> childRelationshipWhiteListMap = new Map<String,List<String>>();
+	 	Map<String, Schema.SObjectType> globalDescribeMap = Schema.getGlobalDescribe();
+    	Schema.SObjectType leadSObjectType = globalDescribeMap.get('Lead');
+		SObject testLead = leadSObjectType.newSObject();
+		testLead.put('FirstName','test');
+		testLead.put('LastName', 'Lead');
+		testLead.put('Company', 'abc');
+		testLead.put('LeadSource', 'lsrc');
+		testLead.put('Street', 'abcStreet');
+		testLead.put('City', 'abcCity');
+		testLead.put('Country', 'abcCountry');
+		testLead.put('State', 'abcState');
+		testLead.put('PostalCode', '123456');
+        insert testLead;
+		String serializedRecord = SObjectDataLoader.serialize(new Set<Id>{testLead.Id}, new SObjectDataLoader.SerializeConfig().auto(testLead.Id.getSObjectType()));
+		Set<Id> leadIdSet = SObjectDataLoader.deserialize(serializedRecord);
+		System.assertEquals(1, leadIdSet.size());
+		List<Lead> leadList = [select LastName, FirstName, Company, LeadSource, Street, City, Country, State, PostalCode from Lead where Id in :leadIdSet];
+		System.assertEquals(1,leadList.size());
+		System.assertEquals('abcState',leadList[0].State);
+		System.assertEquals('abcCountry',leadList[0].Country);
+    }
+    
+     /*
+	* Test  creating a map from json file  
+	*/
+	@isTest(seeAllData=False)
+	private static void testdeserializedRecords()
+    {
+		String accountRecordJsonFile ='{"RecordSetBundles":[{"Records":[{"attributes":{"type":"Account","url":"/services/data/v31.0/sobjects/Account/001b000000dPPN3AAO"},"Name":"TestAccount","SystemModstamp":"2014-09-29T05:06:08.000+0000","CreatedDate":"2014-09-29T05:06:08.000+0000","LastModifiedDate":"2014-09-29T05:06:08.000+0000","IsDeleted":false,"Id":"001b000000dPPN3AAO"}],"ObjectType":"Account"}]}';
+		Map<String,List<Sobject>> recordBundleMap = new Map<String,List<Sobject>>();
+		recordBundleMap = SObjectDataLoader.deserializedRecords(accountRecordJsonFile);
+		System.assert(recordBundleMap.keyset().contains('Account'));
+		List<Account> accList = (List<Account>)recordBundleMap.get('Account');
+		System.assertEquals(accList[0].Name,'TestAccount');
+    }
 }


### PR DESCRIPTION
Added Functionality  so that user can blacklist fields and childrelationships fields whose data user does not wants to serialize.
It also includes functionality for user to omit currency field from getting serialized.
Fix to Filter error on CollaborationGroupRecords