### PR TITLE
fixed #28, fixed #29, fixed #30

### DIFF
--- a/apex-sobjectdataloader/src/classes/SObjectDataLoader.cls
+++ b/apex-sobjectdataloader/src/classes/SObjectDataLoader.cls
@@ -491,7 +491,7 @@ public with sharing class SObjectDataLoader
 							id newRecordTypeId = recordTypeIdMap.get((Id)originalRecord.get('RecordTypeId'));
 							
 							// Update the record with the new Id
-							originalRecord.put('RecordTypeId', newRecordTypeId);
+							newRecord.put('RecordTypeId', newRecordTypeId);
 						}
 					}
 	

--- a/apex-sobjectdataloader/src/classes/SObjectDataLoader.cls
+++ b/apex-sobjectdataloader/src/classes/SObjectDataLoader.cls
@@ -564,7 +564,7 @@ public with sharing class SObjectDataLoader
 			for(SObject originalRecord : recordSetBundle.Records)
 			{
 				if(result.get(originalRecord.Id) == null){
-                    result.put(originalRecord.Id, originalRecord.clone());
+                    result.put(originalRecord.Id, originalRecord.clone().clone());
 				}
 			}
 		}

--- a/apex-sobjectdataloader/src/classes/SObjectDataLoader.cls
+++ b/apex-sobjectdataloader/src/classes/SObjectDataLoader.cls
@@ -501,12 +501,12 @@ public with sharing class SObjectDataLoader
 	                	Set<Schema.SObjectField> unresolvableFieldReferences = new Set<Schema.SObjectField>(); 
 	                	updateReferenceFieldsInRecords(relationshipsFields, resolvableFieldReferences, recordsByOriginalId, originalRecord, unresolvableFieldReferences);
 	                	
-	                	if(!unresolvableFieldReferences.isEmpty() && callback!=null)
+	                	if(!unresolvableFieldReferences.isEmpty() && callback != null)
 	                	{
 	                		UnresolvedReferences unresolveableReferences = new UnresolvedReferences();
 	                		unresolveableReferences.Record = newRecord;
 	                		unresolveableReferences.References = unresolvableFieldReferences;
-	                		callback.unresolvedReferences(sObjectType, new List<UnresolvedReferences>{unresolveableReferences});
+	                		callbackUnresolvedReferencesList.add(unresolveableReferences);
 	                	}
 	                	
 	                	if(!resolvableFieldReferences.isEmpty())
@@ -527,6 +527,12 @@ public with sharing class SObjectDataLoader
 	            	}
 				}
 			}
+            
+            // Let the caller attempt to resolve any references the above could not
+            if(callback != null && !callbackUnresolvedReferencesList.isEmpty())
+            {
+                callback.unresolvedReferences(sObjectType, callbackUnresolvedReferencesList);
+            }
             
             insert recordsToInsert.values();
             recordSetBundle.Records = recordsToInsert.values();

--- a/apex-sobjectdataloader/src/classes/SObjectDataLoader.cls
+++ b/apex-sobjectdataloader/src/classes/SObjectDataLoader.cls
@@ -760,7 +760,8 @@ public with sharing class SObjectDataLoader
 			if(sObjectFieldDescribe.getType() == Schema.DisplayType.Reference)
 				if(!(config.followRelationships.contains(sObjectField) ||
 					 config.keepRelationshipValues.contains(sObjectField) || 
-				     config.followChildRelationships.contains(sObjectField)))
+				     config.followChildRelationships.contains(sObjectField) ||
+				     sObjectField.getDescribe().getName().equals('RecordTypeId')))
 				   continue;
 			// Serialize this field..						
 			serializeFields.add(sObjectField);

--- a/apex-sobjectdataloader/src/classes/SObjectDataLoader.cls
+++ b/apex-sobjectdataloader/src/classes/SObjectDataLoader.cls
@@ -444,15 +444,13 @@ public with sharing class SObjectDataLoader
 		} 
 
 		// Map to track original ID's against the new SObject record instances being inserted
-		Map<Id, SObject> recordsByOriginalId = new Map<Id, SObject>();
+		Map<Id, SObject> recordsByOriginalId = clonesById(recordsBundle.recordSetBundles);
 		
 		// Record set bundles are already ordered in dependency order due to serialisation approach
 		Map<String, Schema.SObjectType> sObjectsByType = Schema.getGlobalDescribe();
 		List<UnresolvedReferences> unresolvedReferencesByRecord = new List<UnresolvedReferences>(); 
 		for(RecordSetBundle recordSetBundle : recordsBundle.recordSetBundles)
 		{
-			// List of records to be inserted after de-serialization
-            List<Sobject> recordsToInsert = new List<Sobject>();
 			// Determine lookup / relationship fields to update prior to inserting these records
 			Schema.SObjectType sObjectType = sObjectsByType.get(recordSetBundle.ObjectType);
 			Map<String, Schema.SObjectField> sObjectFields;
@@ -475,78 +473,67 @@ public with sharing class SObjectDataLoader
 				 		selfReferenceFields.add(sObjectField.getDescribe().getName());
 				 	}
 				}
-					
 			}
+			
+			// List of records to be inserted after de-serialization
+            Map<Id, Sobject> recordsToInsert = new Map<Id, Sobject>();
+            
 			// Prepare records for insert
 			for(SObject originalRecord : recordSetBundle.Records)
 			{
-				// Update the record type ID if this object supports record types
-				if (sObjectFields.containsKey('recordtypeid')) {
-					if (originalRecord.get('RecordTypeId') != null) {
-						// Get the new record type Id 
-						id newRecordTypeId = recordTypeIdMap.get((Id)originalRecord.get('RecordTypeId'));	
-						
-						// Update the record with the new Id
-						originalRecord.put('RecordTypeId', newRecordTypeId);	
+				if(!recordsToInsert.containsKey(originalRecord.Id))
+				{
+					SObject newRecord = recordsByOriginalId.get(originalRecord.Id);
+					// Update the record type ID if this object supports record types
+					if (sObjectFields.containsKey('recordtypeid')) {
+						if (originalRecord.get('RecordTypeId') != null) {
+							// Get the new record type Id
+							id newRecordTypeId = recordTypeIdMap.get((Id)originalRecord.get('RecordTypeId'));
 							
+							// Update the record with the new Id
+							originalRecord.put('RecordTypeId', newRecordTypeId);
+						}
 					}
+	
+	            	if(!relationshipsFields.isEmpty())
+	            	{
+	                	Set<Schema.SObjectField> resolvableFieldReferences = new Set<Schema.SObjectField>();
+	                	Set<Schema.SObjectField> unresolvableFieldReferences = new Set<Schema.SObjectField>(); 
+	                	updateReferenceFieldsInRecords(relationshipsFields, resolvableFieldReferences, recordsByOriginalId, originalRecord, unresolvableFieldReferences);
+	                	
+	                	if(!unresolvableFieldReferences.isEmpty() && callback!=null)
+	                	{
+	                		UnresolvedReferences unresolveableReferences = new UnresolvedReferences();
+	                		unresolveableReferences.Record = newRecord;
+	                		unresolveableReferences.References = unresolvableFieldReferences;
+	                		callback.unresolvedReferences(sObjectType, new List<UnresolvedReferences>{unresolveableReferences});
+	                	}
+	                	
+	                	if(!resolvableFieldReferences.isEmpty())
+	                	{
+	                		UnresolvedReferences unresolvedReferences = new UnresolvedReferences();
+	                		unresolvedReferences.Record = originalRecord;
+	                		unresolvedReferences.References = resolvableFieldReferences;
+	                		unresolvedReferencesByRecord.add(unresolvedReferences);
+	                	}
+	                	else
+	                	{
+	                    	recordsToInsert.put(originalRecord.Id, newRecord);
+	                	}
+	            	}
+	            	else
+	            	{
+	                	recordsToInsert.put(originalRecord.Id, newRecord);
+	            	}
 				}
-
-				// Clone the deserialised SObject to remove the original Id prior to inserting it
-				SObject newRecord = originalRecord.clone().clone();
-				if(recordsByOriginalId.get(originalRecord.Id)==null){
-					// Map the new cloned record to its old Id (once inserted this can be used to obtain the new id)
-                    recordsByOriginalId.put(originalRecord.Id, newRecord);
-                	if(relationshipsFields.size()>0)
-                	{
-                    	Set<Schema.SObjectField> filteredUnresolvedFieldReferences = new Set<Schema.SObjectField>();
-                    	Set<Schema.SObjectField> allUnresolvedFieldReferences = new Set<Schema.SObjectField>(); 
-                    	updateReferenceFieldsInRecords(relationshipsFields,filteredUnresolvedFieldReferences,recordsByOriginalId,originalRecord,allUnresolvedFieldReferences);
-                    // Retain a list of records with unresolved references
-                    	if(allUnresolvedFieldReferences.size()>0)
-                    	{
-                        	if(callback!=null)
-                        	{
-                        		UnresolvedReferences unresolvedReferences = new UnresolvedReferences();
-                        		unresolvedReferences.Record = newRecord;
-                        		unresolvedReferences.References = allUnresolvedFieldReferences;
-                        		callbackUnresolvedReferencesList.add(unresolvedReferences);
-                        	}
-                        	else if(filteredUnresolvedFieldReferences.size()>0)
-                        	{
-                        		UnresolvedReferences unresolvedReferences = new UnresolvedReferences();
-                        		unresolvedReferences.Record = originalRecord;
-                        		unresolvedReferences.References = filteredUnresolvedFieldReferences;
-                        		unresolvedReferencesByRecord.add(unresolvedReferences);
-                        	}
-                    	}
-                    	if(filteredUnresolvedFieldReferences.isEmpty() && callback==null)
-                    	{
-                        	recordsToInsert.add(newRecord);
-                    	}   
-                	}
-                	else
-                	{
-                    	recordsToInsert.add(newRecord);
-                	}
-				}
-            }           
-			List<UnresolvedReferences> newUnResolvedReferenceList = new List<UnresolvedReferences>();
-            // Let the caller attempt to resolve any references the above could not
-            if(callback!=null && callbackUnresolvedReferencesList.size()>0)
-            {
-                callback.unresolvedReferences(sObjectType, callbackUnresolvedReferencesList);
-                for(UnresolvedReferences callBackUnresolvedReference : callbackUnresolvedReferencesList)
-                {
-                		recordsToInsert.add(callBackUnresolvedReference.Record);
-                }
-            }
-           
-            insert recordsToInsert;
-            recordSetBundle.Records = recordsToInsert;
+			}
+            
+            insert recordsToInsert.values();
+            recordSetBundle.Records = recordsToInsert.values();
           	processUnresolvedRecords(unresolvedReferencesByRecord, recordsByOriginalId);
         }
-        if(unresolvedReferencesByRecord.size() >0)
+        
+        if(!unresolvedReferencesByRecord.isEmpty())
         {
         	List<Sobject> unresolvedRecordsToInsert = new List<Sobject>();
         	for(UnresolvedReferences unresolvedReference : unresolvedReferencesByRecord)
@@ -558,39 +545,52 @@ public with sharing class SObjectDataLoader
         // Return Id list from the first bundle set
         return new Map<Id, SObject>(recordsBundle.recordSetBundles[0].Records).keySet();
     }
+    
+	
+    /*
+    *  Method clones the deserialized Objects
+    */
+    private static Map<Id, SObject> clonesById(List<RecordSetBundle> bundles) {
+    	Map<Id, SObject> result = new Map<Id, SObject>();
+    	
+    	for(RecordSetBundle recordSetBundle : bundles)
+		{
+			for(SObject originalRecord : recordSetBundle.Records)
+			{
+				if(result.get(originalRecord.Id) == null){
+                    result.put(originalRecord.Id, originalRecord.clone());
+				}
+			}
+		}
+		
+    	return result;
+    }
 	
 	/*
     *  Method to Update foreign key references / lookups / master-detail relationships
     */
-    private static void updateReferenceFieldsInRecords(List<Schema.SObjectField> relationshipsFields,Set<Schema.SObjectField> filteredUnresolvedFieldReferences,Map<Id, SObject> recordsByOriginalId,Sobject orignalRecord,Set<Schema.SObjectField> allUnresolvedFieldReferences)
+    private static void updateReferenceFieldsInRecords(List<Schema.SObjectField> relationshipsFields,Set<Schema.SObjectField> resolvableFieldReferences,Map<Id, SObject> recordsByOriginalId,Sobject orignalRecord,Set<Schema.SObjectField> unresolveableFieldReferences)
     {
     	for(Schema.SObjectField sObjectField : relationshipsFields)
-		{                           
-			// Obtained original related record Id and search map over new records by old Ids
+		{
 			Id oldRelatedRecordId = (Id) orignalRecord.get(sObjectField);
-			if(oldRelatedRecordId!=null )
+			SObject newRelatedRecord = recordsByOriginalId.get(oldRelatedRecordId);
+			
+			if(newRelatedRecord != null && newRelatedRecord.Id != null)
 			{
-				SObject newRelatedRecord = recordsByOriginalId.get(oldRelatedRecordId);
-				Sobject newRecord ;
-				if(newRelatedRecord!=null && newRelatedRecord.Id!=null)
-				{
-					newRecord = recordsByOriginalId.get(orignalRecord.ID);
-					newRecord.put(sObjectField, newRelatedRecord.Id);
-				}
-				else
-				{
-					filteredUnresolvedFieldReferences.add(sObjectField);
-				}
- 			}
- 			else if(allUnresolvedFieldReferences!=null)
+				Sobject newRecord = recordsByOriginalId.get(orignalRecord.Id);
+				newRecord.put(sObjectField, newRelatedRecord.Id);
+			}
+			else if(newRelatedRecord != null)
+			{
+				resolvableFieldReferences.add(sObjectField);
+			}
+ 			else if(unresolveableFieldReferences != null)
  			{
- 				allUnresolvedFieldReferences.add(sObjectField);
+ 				unresolveableFieldReferences.add(sObjectField);
  			}
 		}
-			if(allUnresolvedFieldReferences!=null)
-			{
-				allUnresolvedFieldReferences.addAll(filteredUnresolvedFieldReferences);
-			}
+		
     }
 
  	/*
@@ -600,17 +600,16 @@ public with sharing class SObjectDataLoader
     {
     
    		List<UnresolvedReferences> unresolvedReferences = new List<UnresolvedReferences>(); 
-   		Integer recordsSize = unresolvedReferencesByRecord.size();
-        if(recordsSize >0)
+        if(!unresolvedReferencesByRecord.isEmpty())
         {
-            List<Sobject> insertResolvedRecords = new List<Sobject>();
+            List<Sobject> resolvedRecords = new List<Sobject>();
             for(UnresolvedReferences filteredReference : unresolvedReferencesByRecord)
             {
                 List <Schema.SObjectField> referenceFields = new List<Schema.SObjectField>(filteredReference.References);
                 Set<Schema.SobjectField> filteredreferenceFields = new Set<Schema.SobjectField>();
                 Sobject oldRecord = filteredReference.Record;
                 SObject unprocessedRecord = recordsByOriginalId.get(oldRecord.Id);
-                updateReferenceFieldsInRecords(referenceFields, filteredreferenceFields, recordsByOriginalId, oldRecord,null);
+                updateReferenceFieldsInRecords(referenceFields, filteredreferenceFields, recordsByOriginalId, oldRecord, null);
                 if(filteredreferenceFields.size() >0)
                 {
                      filteredReference.References = filteredreferenceFields;
@@ -618,16 +617,16 @@ public with sharing class SObjectDataLoader
                 }
                 else
                 {
-                     insertResolvedRecords.add(unprocessedRecord);
+                     resolvedRecords.add(unprocessedRecord);
                 }
             }
             unresolvedReferencesByRecord.clear();
             unresolvedReferencesByRecord.addAll(unresolvedReferences);
 
-            if(insertResolvedRecords.size()>0)
+            if(!resolvedRecords.isEmpty())
             {
-                insert insertResolvedRecords;
-                processUnresolvedRecords(unresolvedReferencesByRecord,recordsByOriginalId);
+                insert resolvedRecords;
+                processUnresolvedRecords(unresolvedReferencesByRecord, recordsByOriginalId);
             }       
         }
     }

--- a/apex-sobjectdataloader/src/classes/SObjectDataLoaderTest.cls
+++ b/apex-sobjectdataloader/src/classes/SObjectDataLoaderTest.cls
@@ -487,7 +487,7 @@ private class SObjectDataLoaderTest {
  		// Execute
  		Exception unexpected = null;
  		try {
-        	SObjectDataLoader.deserialize(jsonString, new TestConfig());
+        	SObjectDataLoader.deserialize(jsonString, new TestCallback());
  		}
  		catch(DmlException dmlEx) {
  			unexpected = dmlEx;
@@ -847,7 +847,7 @@ private class SObjectDataLoaderTest {
     
     // INNER CLASSES
     
-    public class TestConfig implements SObjectDataLoader.IDeserializeCallback {
+    public class TestCallback implements SObjectDataLoader.IDeserializeCallback {
 		public void unresolvedReferences(SObjectType soType, List<SObjectDataLoader.UnresolvedReferences> unresolved) {
 			//doAnything
 		}

--- a/apex-sobjectdataloader/src/classes/SObjectDataLoaderTest.cls
+++ b/apex-sobjectdataloader/src/classes/SObjectDataLoaderTest.cls
@@ -271,7 +271,7 @@ private class SObjectDataLoaderTest {
             Set<Id> resultIds = SObjectDataLoader.deserialize(serializedData);
             
             //dynamic soql will prevent any compile time errors if RecordTypeId field doesn't exist
-            String accountsQuery = 'SELECT Id, RecordTypeId FROM Account WHERE Id IN :newAccountIds';
+            String accountsQuery = 'SELECT Id, RecordTypeId FROM Account WHERE Id IN :resultIds';
             testAccounts = Database.query(accountsQuery);
             Set<Id> recordTypeIdsOfNewAccounts = new Set<Id>();
 
@@ -454,10 +454,6 @@ private class SObjectDataLoaderTest {
         {
             testObjectJson = testObjectJson.remove('"CurrencyIsoCode":"USD",');
         }
-        
-        delete [Select Id from Account where Name = 'ChildAccount']; 
-        delete [Select Id from Account where Name = 'Parent Account']; 
-        delete [Select Id from Contact where Name = 'MyContact'];
 
  		//Importing Records
         Set<Id> resultIds = SObjectDataLoader.deserialize(testObjectJson);
@@ -470,6 +466,35 @@ private class SObjectDataLoaderTest {
         system.assertEquals(contactRecords.size(), 1);
         system.assertEquals(parentAccountRecords[0].Id, childAccountRecords[0].ParentId);
         system.assertEquals(childAccountRecords[0].Id,contactRecords[0].AccountId);
+    }
+    
+     /*
+    * Donot save an record subcomponent if error occurs
+    */
+     @isTest(seeAllData=False)
+     private static void unorderedRecordsinJsonWontFailWithConfig()
+    {
+    	// Setup
+        String jsonString = '{"RecordSetBundles":[{"Records":[{"attributes":{"type":"Contact","url":"/services/data/v29.0/sobjects/Contact/003b000000NStFRAA1"},'+
+        '"IsEmailBounced":false,"HasOptedOutOfFax":false,"LastModifiedDate":"2014-03-01T12:32:28.000+0000","HasOptedOutOfEmail":false,'+
+        '"LastName":"MyContact","Name":"MyContact","DoNotCall":false,"AccountId":"001b000000P8LZgAAN","SystemModstamp":"2014-03-01T12:32:28.000+0000","CreatedDate":"2014-03-01T12:11:58.000+0000",'+
+        '"IsDeleted":false,"Id":"003b000000NStFRAA1"}],"ObjectType":"Contact"},{"Records":[{"attributes":{"type":"Account","url":"/services/data/v29.0/sobjects/Account/001b000000P8LZgAAN"},'+
+        '"Name":"ChildAccount","ParentId":"001b000000PBLqsAAH","SystemModstamp":"2014-03-06T06:04:38.000+0000","CreatedDate":"2014-03-01T11:42:34.000+0000",'+
+        '"LastModifiedDate":"2014-03-06T06:04:38.000+0000","IsDeleted":false,"Id":"001b000000P8LZgAAN"},{"attributes":{"type":"Account","url":"/services/data/v29.0/sobjects/Account/001b000000PBLqsAAH"},'+
+        '"Name":"Parent Account","SystemModstamp":"2014-03-06T06:04:15.000+0000","CreatedDate":"2014-03-06T06:04:15.000+0000","LastModifiedDate":"2014-03-06T06:04:15.000+0000",'+
+        '"IsDeleted":false,"Id":"001b000000PBLqsAAH"}],"ObjectType":"Account"}]}';
+		
+ 		// Execute
+ 		Exception unexpected = null;
+ 		try {
+        	SObjectDataLoader.deserialize(jsonString, new TestConfig());
+ 		}
+ 		catch(DmlException dmlEx) {
+ 			unexpected = dmlEx;
+ 		}
+        
+        //Verify
+        System.assertEquals(null, unexpected);
     }
     
     @isTest(seeAllData=False)
@@ -818,4 +843,13 @@ private class SObjectDataLoaderTest {
         //Verify
         System.assertNotEquals(null, expectedException);
     }
+    
+    
+    // INNER CLASSES
+    
+    public class TestConfig implements SObjectDataLoader.IDeserializeCallback {
+		public void unresolvedReferences(SObjectType soType, List<SObjectDataLoader.UnresolvedReferences> unresolved) {
+			//doAnything
+		}
+	}
 }


### PR DESCRIPTION
- Serialize RecordTypeId explicitly, so tests won't fail. Details at: https://salesforce.stackexchange.com/questions/195122/recordtypeid-is-not-queried-in-tests

- Made the default reference resolving independent from custom callback resolver