### PR TITLE
Update SObjectDataLoaderTest.cls

### DIFF
--- a/apex-sobjectdataloader/src/classes/SObjectDataLoaderTest.cls
+++ b/apex-sobjectdataloader/src/classes/SObjectDataLoaderTest.cls
@@ -340,7 +340,12 @@ private class SObjectDataLoaderTest {
         Set<Id> childAccountIds = new Set<Id>();
         childAccountIds.add(childAccount2.Id);
         //Records are exported
-        String serializedData = SObjectDataLoader.serialize(childAccountIds);
+        String serializedData = SObjectDataLoader.serialize(
+					childAccountIds, 
+					new SObjectDataLoader.SerializeConfig()
+						.maxLookupDepth(4)
+						.maxChildDepth(4)
+						.follow(Account.ParentId));
         
         Integer recordsBeforeDeletion = [Select count() from Account];
         List<Account> recordsToDelete =  new List<Account>();


### PR DESCRIPTION
In current version of this repo, `SobjectDataLoaderTest.deserializingObjectsWithSelfReferncesLevel2` fails with this error and stackTrace:

    SObjectDataLoader.PreventInfinityLoopException: 
    Maximum Referencing field depth of 3 is reached

```
Class.SObjectDataLoader: line 658, column 1
Class.SObjectDataLoader: line 717, column 1
Class.SObjectDataLoader: line 717, column 1
Class.SObjectDataLoader: line 717, column 1
Class.SObjectDataLoader: line 400, column 1
Class.SObjectDataLoader: line 352, column 1
Class.SObjectDataLoaderTest.deserializingObjectsWithSelfReferncesLevel2: line 343, column 1
```

Change testmethod to set maxLevel to 4 from default level 3