### PR TITLE
Updated code to handle the same record type name of two different packages

### DIFF
--- a/apex-sobjectdataloader/src/classes/SObjectDataLoader.cls
+++ b/apex-sobjectdataloader/src/classes/SObjectDataLoader.cls
@@ -425,9 +425,9 @@ public with sharing class SObjectDataLoader
 			JSON.deserialize(recordsBundleAsJSON, SObjectDataLoader.RecordsBundle.class);
 		
 		// Get current record types that are in the bundle and see if they exist in the current database
-		Map<String, RecordType> currentRecordTypeMap = new Map<String, RecordType>();
+		Map<Id, RecordType> currentRecordTypeMap = new Map<Id, RecordType>();
 		for (RecordType rt : [SELECT Id, Description, DeveloperName, Name, SobjectType FROM RecordType]) {
-			currentRecordTypeMap.put(rt.SObjectType + '.' + rt.DeveloperName, rt);
+			currentRecordTypeMap.put(rt.Id, rt);
 		} 
 
 		// Create a map from imported record type IDs to new ones
@@ -435,7 +435,7 @@ public with sharing class SObjectDataLoader
 		if (recordsBundle.recordTypeMap != null) {
 			for (RecordType rt : recordsBundle.recordTypeMap.values()) {
 				// Get the current record type that matches the imported one
-				RecordType currentRecordType = currentRecordTypeMap.get(rt.SObjectType + '.' + rt.DeveloperName);
+				RecordType currentRecordType = currentRecordTypeMap.get(rt.Id);
 			
 				// Add this to the map
 				recordTypeIdMap.put(rt.Id, currentRecordType.Id);
@@ -862,7 +862,7 @@ public with sharing class SObjectDataLoader
 			}
 			
 			// Get all of the record types that are included
-			recordTypeMap = new Map<Id, RecordType>([SELECT Id, Description, DeveloperName, Name, SobjectType FROM RecordType WHERE Id=:recordTypeIds]);
+			recordTypeMap = new Map<Id, RecordType>([SELECT Id, Description, DeveloperName, Name, SobjectType FROM RecordType WHERE Id IN :recordTypeIds]);
 						
 		} 		
 	}

--- a/apex-sobjectdataloader/src/classes/SObjectDataLoader.cls
+++ b/apex-sobjectdataloader/src/classes/SObjectDataLoader.cls
@@ -425,9 +425,10 @@ public with sharing class SObjectDataLoader
 			JSON.deserialize(recordsBundleAsJSON, SObjectDataLoader.RecordsBundle.class);
 		
 		// Get current record types that are in the bundle and see if they exist in the current database
-		Map<Id, RecordType> currentRecordTypeMap = new Map<Id, RecordType>();
-		for (RecordType rt : [SELECT Id, Description, DeveloperName, Name, SobjectType FROM RecordType]) {
-			currentRecordTypeMap.put(rt.Id, rt);
+		Map<String, RecordType> currentRecordTypeMap = new Map<String, RecordType>();
+		for (RecordType rt : [SELECT Id, Description, DeveloperName, Name, SobjectType, NamespacePrefix FROM RecordType]) {
+			currentRecordTypeMap.put(rt.DeveloperName, rt);
+			currentRecordTypeMap.put(rt.NamespacePrefix + rt.DeveloperName, rt);
 		} 
 
 		// Create a map from imported record type IDs to new ones
@@ -435,7 +436,8 @@ public with sharing class SObjectDataLoader
 		if (recordsBundle.recordTypeMap != null) {
 			for (RecordType rt : recordsBundle.recordTypeMap.values()) {
 				// Get the current record type that matches the imported one
-				RecordType currentRecordType = currentRecordTypeMap.get(rt.Id);
+				RecordType currentRecordType = (rt.NamespacePrefix == null) ? currentRecordTypeMap.get(rt.DeveloperName) :
+																			  currentRecordTypeMap.get(rt.NamespacePrefix + rt.DeveloperName);
 			
 				// Add this to the map
 				recordTypeIdMap.put(rt.Id, currentRecordType.Id);
@@ -862,7 +864,7 @@ public with sharing class SObjectDataLoader
 			}
 			
 			// Get all of the record types that are included
-			recordTypeMap = new Map<Id, RecordType>([SELECT Id, Description, DeveloperName, Name, SobjectType FROM RecordType WHERE Id IN :recordTypeIds]);
+			recordTypeMap = new Map<Id, RecordType>([SELECT Id, Description, DeveloperName, Name, SobjectType, NamespacePrefix FROM RecordType WHERE Id IN :recordTypeIds]);
 						
 		} 		
 	}


### PR DESCRIPTION
If you have two packages installed and they contain the same record type (same name and api name, but other package prefix), only one of them is in the currentRecordTypeMap (will be overwritten). SObjectType and DeveloperName are not unique, I changed it to the NamespacePrefix + DeveloperName.